### PR TITLE
IS_CHINA 판별을 위한 aws 명령어 제거

### DIFF
--- a/default.sh
+++ b/default.sh
@@ -9,10 +9,10 @@ THIS_VERSION="v0.0.0"
 DEBUG_MODE=false
 
 IS_CHINA=false
-CURRENT_REGION=$(aws configure get region)
-if [[ "${CURRENT_REGION}" == "cn-"* ]]; then
-  IS_CHINA=true
-fi
+#CURRENT_REGION=$(aws configure get region)
+#if [[ "${CURRENT_REGION}" == "cn-"* ]]; then
+#  IS_CHINA=true
+#fi
 
 HARBOR_PROJECT="opsnow"
 


### PR DESCRIPTION
초기에 툴 설치할때 awscli 를 설치하는데 이때 에러 발생함. awscli가 설치되지 않는 상태에서 aws 명령어가 실행됨.