### PR TITLE
nginx-ingress 메모리 사용율 관련 에러 Fix

### DIFF
--- a/charts/kube-ingress/nginx-ingress-nodeport.yaml
+++ b/charts/kube-ingress/nginx-ingress-nodeport.yaml
@@ -1,14 +1,17 @@
 # chart-repo: stable/nginx-ingress
-# chart-version: 1.31.0
+# chart-version: 1.36.3
 
 nameOverride: nginx-ingress-nodeport
 
 controller:
   image:
     repository: QUAY/kubernetes-ingress-controller/nginx-ingress-controller
-    tag: "0.28.0"
-  # kind: DaemonSet
-  replicaCount: 2
+
+  ## This will fix the issue of HPA not being able to read the metrics.
+  ## Note that if you enable it for existing deployments, it won't work as the labels are immutable.
+  ## We recommend setting this to true for new deployments.
+  useComponentLabel: true
+  
   ## Configures the ports the nginx-controller listens on
   containerPort:
     http: 80
@@ -31,9 +34,9 @@ controller:
     ## Target CPU utilization percentage to scale
     ## The target average CPU utilization (represented as a percent of requested CPU) over all the pods.
     ## If it's not specified or negative, a default autoscaling policy will be used.
-    targetCPUUtilizationPercentage: "60"
+    targetCPUUtilizationPercentage: 60
     ## Target memory utilization percentage to scale
-    targetMemoryUtilizationPercentage: "60"
+    targetMemoryUtilizationPercentage: 60
   ## autoscaling 적용하면 아래 설정이 적용되지 않음
   #replicaCount: 2
   #minAvailable: 1


### PR DESCRIPTION
nginx-ingress hlem chart를 최신 버전으로 올리고 useComponentLabel 설정값을 true로 설정함.
  ## This will fix the issue of HPA not being able to read the metrics.
  ## Note that if you enable it for existing deployments, it won't work as the labels are immutable.
  ## We recommend setting this to true for new deployments.
  useComponentLabel: true